### PR TITLE
1. 탈퇴 구현 수정

### DIFF
--- a/src/main/java/com/kh/reading_fly/WebConfig.java
+++ b/src/main/java/com/kh/reading_fly/WebConfig.java
@@ -23,7 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(new LoginCheckInterceptor())
-        .order(1)
+        .order(2)
         .addPathPatterns("/**")
         .addPathPatterns("/member/**")
         .addPathPatterns("/board/**")
@@ -31,29 +31,37 @@ public class WebConfig implements WebMvcConfigurer {
 
 
         .excludePathPatterns(
-            "/",
-            "/login",
-            "/logout",
-            "/signup",
-            "/board",
-            "/notices/all",
             "/css/**",
             "/js/**",
             "/img/**",
-            "/member/findid",
-            "/member/findpw"
+
+            "/",                          // 메인화면
+            "/login",                     // 로그인
+            "/logout",                    // 로그아웃
+            "/signup",                    // 회원가입
+            "/member/outCompleted",       // 회원탈퇴 완료
+            "/memberexist/**",             // id 및 pw 찾기 관련 일체
+
+
+
+            "/board",                     // 게시판 목록 보기
+            "/board/*/detail",            // 게시판 내용 보기
+            "/notices/all",                // 공지사항 목록 보기
+            "/error/**"
+
+
 
         );
 
 
-//    registry.addInterceptor(new AdminCheckInterceptor())
-//        .order(2)
-//        .addPathPatterns("/admin/**")
-//        .addPathPatterns("/notices/")
-//
-//        .excludePathPatterns(
-//
-//        );
+    registry.addInterceptor(new AdminCheckInterceptor())
+        .order(1)
+        .addPathPatterns("/admin/**")
+        .addPathPatterns("/notices/")
+
+        .excludePathPatterns(
+
+        );
 
 
   }

--- a/src/main/java/com/kh/reading_fly/domain/member/dao/MemberDAO.java
+++ b/src/main/java/com/kh/reading_fly/domain/member/dao/MemberDAO.java
@@ -30,6 +30,7 @@ public interface MemberDAO {
   //관리자 코드 확인
   String admin(String id);
 
+
   // 관리자 전체 회원 확인
   List<MemberDTO> allMemberList();
 
@@ -39,7 +40,7 @@ public interface MemberDAO {
   // 관리자 탈퇴 회원 확인
   List<MemberDTO> dleMemberList();
 
-  // 사용자  id 조회 또는 수정용 id 조회
+  // 사용자 id 조회 또는 수정용 id 조회
   MemberDTO findByID(String id);
 
   // 사용자 email 조회 - 사용 확인 필요

--- a/src/main/java/com/kh/reading_fly/domain/member/dao/MemberDAOImpl.java
+++ b/src/main/java/com/kh/reading_fly/domain/member/dao/MemberDAOImpl.java
@@ -92,7 +92,8 @@ public class MemberDAOImpl implements MemberDAO{
   @Override
   public MemberDTO login(String id, String pw) {
     StringBuffer sql = new StringBuffer();
-    sql.append("select id, pw from member ");
+//    sql.append("select id, pw from member ");
+    sql.append("select id, pw, name, email, nickname, admin_fl, signup_dt from member ");
     sql.append(" where id = ? and pw = ? and leave_fl = 0  ");
     List<MemberDTO> list = jdbcTemplate.query(sql.toString(),
             new BeanPropertyRowMapper<>(MemberDTO.class), id, pw );
@@ -163,12 +164,13 @@ public class MemberDAOImpl implements MemberDAO{
     return list;
   }
 
-  // 사용자  id 조회 또는 수정용 id 조회
+  // 사용자 id 조회 또는 수정용 id 조회
   @Override
   public MemberDTO findByID(String id) {
 
     StringBuffer sql = new StringBuffer();
-    sql.append("select id, email, pw, name, nickname from member ");
+//    sql.append("select id, email, pw, name, nickname from member ");
+    sql.append("select id, email, pw, name, nickname, admin_fl, signup_dt, leave_fl, leave_dt from member ");
     sql.append(" where id = ? ");
     MemberDTO memberDTO = jdbcTemplate.queryForObject(sql.toString(),
             new BeanPropertyRowMapper<>(MemberDTO.class), id);

--- a/src/main/java/com/kh/reading_fly/domain/member/dto/MemberDTO.java
+++ b/src/main/java/com/kh/reading_fly/domain/member/dto/MemberDTO.java
@@ -12,17 +12,15 @@ import java.time.LocalDateTime;
 @Data
 public class MemberDTO {
 
-  private String id;
-  private String pw;
-  private String name;
-  private String nickname;
-  private String email;
-
-//  private LocalDateTime signup_dt;
-//
-//  private String leave_fl;
-//
-//  private LocalDateTime leave_dt;
+  private String id;                      // 아이디 id VARCHAR2(40) not null
+  private String pw;                      // 비밀번호 pw VARCHAR2(30) not null
+  private String name;                    // 이름 name VARCHAR2(20) not null
+  private String email;                   // 이메일 email VARCHAR2(50) not null
+  private String nickname;                // 닉네임 nickname VARCHAR2(30) not null
+  private int admin_fl;                   // 관리자여부 2 관리자 3 사용자 admin_fl NUMBER(1) default 3
+  private LocalDateTime signup_dt;        // 가입시간 signup_dt TIMESTAMP  default systimestamp
+  private int leave_fl;                   // 탈퇴여부 0 회원 1 탈퇴 leave_fl NUMBER(1) default 0
+  private LocalDateTime leave_dt;          // 탈퇴시간 leave_dt TIMESTAMP
 
 
 

--- a/src/main/java/com/kh/reading_fly/web/controller/AdminController.java
+++ b/src/main/java/com/kh/reading_fly/web/controller/AdminController.java
@@ -2,14 +2,18 @@ package com.kh.reading_fly.web.controller;
 
 import com.kh.reading_fly.domain.member.dto.MemberDTO;
 import com.kh.reading_fly.domain.member.svc.MemberSVC;
+import com.kh.reading_fly.web.form.login.LoginMember;
 import com.kh.reading_fly.web.form.member.MemberDetailForm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.util.List;
 
 @Slf4j
@@ -57,6 +61,33 @@ public class AdminController {
 
     return "member/adminMemberDetail";
   }
+
+//  @GetMapping("/memberdetail")
+//  public String memberid(
+//      @PathVariable("id") String id,
+//      HttpServletRequest request,
+//      Model model){
+//
+//
+//    HttpSession session = request.getSession(false);
+//    LoginMember loginMember
+//        = (LoginMember)session.getAttribute("loginMember");
+//
+//    MemberDTO memberDTO = memberSVC.findByID(loginMember.getId());
+//    log.info("memberDTO={}", memberDTO);
+//
+//    MemberDetailForm memberdetailForm = new MemberDetailForm();
+//    BeanUtils.copyProperties(memberDTO, memberdetailForm);
+//    log.info("memberdetailForm={}", memberdetailForm);
+//    model.addAttribute("memberdetailForm", memberdetailForm);
+//
+//    return "member/adminMemberDetail";
+//  }
+//
+
+
+
+
 
 
 

--- a/src/main/java/com/kh/reading_fly/web/controller/ApiSupportController.java
+++ b/src/main/java/com/kh/reading_fly/web/controller/ApiSupportController.java
@@ -22,14 +22,38 @@ import javax.validation.Valid;
 @Slf4j
 @Controller
 @RequiredArgsConstructor
+@RequestMapping("/memberexist")
 public class ApiSupportController {
 
   private final MemberSVC memberSVC;
 
 
+
+  //아이디 찾기
+  @GetMapping("/findid")
+  public String findid(){
+    log.info("findIdForm() 호출됨!");
+    return "member/findIdForm";
+  }
+
+  //pw 찾기
+  @GetMapping("/findpw")
+  public String findpw(){
+    log.info("findPwForm() 호출됨!");
+    return "member/findPwForm";
+  }
+
+
+
+
+
+
+
+
+
   // id 찾기 확인
   @ResponseBody
-  @PutMapping("/api/findid")
+  @PutMapping("/exist/findid")
   public JsonResult<String> findIdMember(
           @RequestBody FindIdReq findIdReq, BindingResult bindingResult){
 
@@ -50,7 +74,7 @@ public class ApiSupportController {
 
   // pw 찾기 획인
   @ResponseBody
-  @PutMapping("/api/findpw")
+  @PutMapping("/exist/findpw")
   public JsonResult<String> findPwMember(
           @RequestBody FindPwReq findPwReq, BindingResult bindingResult){
 

--- a/src/main/java/com/kh/reading_fly/web/controller/LoginController.java
+++ b/src/main/java/com/kh/reading_fly/web/controller/LoginController.java
@@ -73,7 +73,14 @@ public class LoginController {
 //    }
 
     //회원 세션 정보
-    LoginMember loginMember = new LoginMember(memberDTO.getId(), memberDTO.getEmail(), memberDTO.getNickname());
+//    LoginMember loginMember = new LoginMember(memberDTO.getId(), memberDTO.getEmail(), memberDTO.getNickname());
+    LoginMember loginMember = new LoginMember(
+        memberDTO.getId(), memberDTO.getNickname(), memberDTO.getEmail(), memberDTO.getAdmin_fl());
+    log.info("id={}, email={}, nickname={}, admin_fl={}",
+        memberDTO.getId(), memberDTO.getEmail(),memberDTO.getNickname(), memberDTO.getAdmin_fl());
+
+
+
 
     //인증성공
     //세션이 있으면 세션 반환, 없으면 새로이 생성

--- a/src/main/java/com/kh/reading_fly/web/controller/MemberController.java
+++ b/src/main/java/com/kh/reading_fly/web/controller/MemberController.java
@@ -199,13 +199,38 @@ public class MemberController {
 
   //회원탈퇴
 //  @GetMapping("/{id}/out")
+//  @GetMapping("/out")
+//  public String outForm(@ModelAttribute OutForm outForm){
+//    log.info("outForm 호출됨!");
+//    return "member/outForm";
+//  }
+
   @GetMapping("/out")
-  public String outForm(@ModelAttribute OutForm outForm){
-    log.info("outForm 호출됨!");
+  public String outForm(HttpServletRequest request,
+                        Model model) {
+    HttpSession session = request.getSession(false);
+    LoginMember loginMember
+        = (LoginMember)session.getAttribute("loginMember");
+
+    //세션이 없으면 로그인 페이지로 이동
+    if(loginMember == null) return "redirect:/";
+
+    //회원정보 가져오기
+    MemberDTO memberDTO =  memberSVC.findByID(loginMember.getId());
+    OutForm outForm = new OutForm();
+    BeanUtils.copyProperties(memberDTO, outForm);
+    model.addAttribute("outForm", outForm);
     return "member/outForm";
   }
 
-  @PostMapping("/out")
+
+
+
+
+
+
+//  @PostMapping("/out")
+  @PatchMapping("/out")
   public String out(
           @Valid @ModelAttribute OutForm outForm,
           BindingResult bindingResult,
@@ -215,19 +240,22 @@ public class MemberController {
     //1)유효성체크
     if(bindingResult.hasErrors()){
       log.info("bindingResult={}",bindingResult);
-      return "/member/outForm";
+//      return "/member/outForm";
+      return "redirect:/member/out";
     }
     //2)동의 체크여부
     if(!outForm.getAgree()){
       bindingResult.rejectValue("agree",null, "탈퇴 안내를 확인하고 동의해 주세요.");
-      return "/member/outForm";
+//      return "/member/outForm";
+      return "redirect:/member/out";
     }
 
     //3) 비밀번호가 일치하는지 체크
     if(!memberSVC.isMember(outForm.getId(), outForm.getPw())){
       bindingResult.rejectValue("pw","memberDTO.pwChk");
       log.info("bindingResult={}", bindingResult);
-      return "member/outForm";
+//      return "member/outForm";
+      return "redirect:/member/out";
     }
 
     //4) 탈퇴로직 수행
@@ -248,21 +276,21 @@ public class MemberController {
 
 
 
-  //아이디 찾기
-  @GetMapping("/findid")
-  public String findid(){
-    log.info("findIdForm() 호출됨!");
-    return "member/findIdForm";
-  }
-
-  //pw 찾기
-  @GetMapping("/findpw")
-  public String findpw(){
-    log.info("findPwForm() 호출됨!");
-    return "member/findPwForm";
-  }
-
-
+//  //아이디 찾기
+//  @GetMapping("/findid")
+//  public String findid(){
+//    log.info("findIdForm() 호출됨!");
+//    return "member/findIdForm";
+//  }
+//
+//  //pw 찾기
+//  @GetMapping("/findpw")
+//  public String findpw(){
+//    log.info("findPwForm() 호출됨!");
+//    return "member/findPwForm";
+//  }
+//
+//
 
 
 

--- a/src/main/java/com/kh/reading_fly/web/controller/SignupController.java
+++ b/src/main/java/com/kh/reading_fly/web/controller/SignupController.java
@@ -77,13 +77,13 @@ public class SignupController {
 
     //4)정상처리로직
     log.info("signupForm={}", signupForm);
-    MemberDTO memberDTO = new MemberDTO( signupForm.getId(), signupForm.getEmail(),
-            signupForm.getPw(), signupForm.getName(), signupForm.getNickname());
+//    MemberDTO memberDTO = new MemberDTO( signupForm.getId(), signupForm.getEmail(),
+//            signupForm.getPw(), signupForm.getName(), signupForm.getNickname());
 //    MemberDTO memberDTO = new MemberDTO( signupForm.getId(), signupForm.getEmail(),
 //        signupForm.getPw(), signupForm.getName(), signupForm.getNickname(),
 //        signupForm.getSignup_dt(), signupForm.getLeave_fl(), signupForm.getLeave_dt());
 
-//    MemberDTO mdto = new MemberDTO();
+    MemberDTO memberDTO = new MemberDTO();
     BeanUtils.copyProperties(signupForm, memberDTO);
     memberSVC.insertMember(memberDTO);
     log.info("id={}, pw={}, name={}, email={}, nickname={}",

--- a/src/main/java/com/kh/reading_fly/web/form/login/LoginMember.java
+++ b/src/main/java/com/kh/reading_fly/web/form/login/LoginMember.java
@@ -12,4 +12,6 @@ public class LoginMember {
   private String nickname;
   private String email;
 
+  private int admin_fl;
+
 }

--- a/src/main/java/com/kh/reading_fly/web/form/member/OutForm.java
+++ b/src/main/java/com/kh/reading_fly/web/form/member/OutForm.java
@@ -2,16 +2,25 @@ package com.kh.reading_fly.web.form.member;
 
 import lombok.Data;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 
 @Data
 public class OutForm {
 
   private String id;
 
+  private String name;
+
+  private String nickname;
+
+  private String email;
 
   @NotBlank
   private String pw;
 
   private Boolean agree;
+
+
 }

--- a/src/main/java/com/kh/reading_fly/web/interceptor/AdminCheckInterceptor.java
+++ b/src/main/java/com/kh/reading_fly/web/interceptor/AdminCheckInterceptor.java
@@ -1,6 +1,7 @@
 package com.kh.reading_fly.web.interceptor;
 
 
+import com.kh.reading_fly.domain.member.dto.MemberDTO;
 import com.kh.reading_fly.domain.member.svc.MemberSVC;
 import com.kh.reading_fly.web.form.login.LoginMember;
 import lombok.extern.slf4j.Slf4j;
@@ -15,16 +16,14 @@ import java.net.URLEncoder;
 public class AdminCheckInterceptor implements HandlerInterceptor{
 
   private MemberSVC memberSVC;
+  private MemberDTO memberDTO;
 
-  public void setMemberSVC(MemberSVC memberSVC) {
-    this.memberSVC = memberSVC;
-  }
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
     String redirectUrl = null;
     String requestURI = request.getRequestURI();
-    log.info("requestURI={}", requestURI);
+    log.info("admin_requestURI={}", requestURI);
 
     if(request.getQueryString() != null){
       String queryString = URLEncoder.encode(request.getQueryString(), "UTF-8");
@@ -38,9 +37,16 @@ public class AdminCheckInterceptor implements HandlerInterceptor{
     }
 
 
-    HttpSession session = request.getSession(false);
-    LoginMember loginMember = (LoginMember) session.getAttribute("loginMember");
-    int code = Integer.parseInt(memberSVC.admin(loginMember.getId()));
+
+    LoginMember loginMember = new LoginMember(
+        memberDTO.getId(), memberDTO.getNickname(), memberDTO.getEmail(), memberDTO.getAdmin_fl());
+    log.info("id={}, email={}, nickname={}, admin_fl={}",
+        memberDTO.getId(), memberDTO.getEmail(),memberDTO.getNickname(), memberDTO.getAdmin_fl());
+    HttpSession session = request.getSession(true);
+    session.setAttribute("loginMember", loginMember );
+
+    int code = loginMember.getAdmin_fl();
+//    int code = Integer.parseInt(memberSVC.admin(loginMember.getId()));
     if(code == 2) {
       log.info("admin 인증 요청");
       response.sendRedirect("/redirectUrl=" + redirectUrl);
@@ -48,11 +54,25 @@ public class AdminCheckInterceptor implements HandlerInterceptor{
     }
 
 
+
+
+//    LoginMember loginMember = (LoginMember) session.getAttribute("loginMember");
+//    int code = Integer.parseInt(memberSVC.admin(loginMember.getId()));
+//    if(code == 2) {
+//      log.info("admin 인증 요청");
+//      response.sendRedirect("/redirectUrl=" + redirectUrl);
+//      return false;
+//    }
+
+
+
 //    if(session == null || session.getAttribute("loginMember.admin_fl") == "3" ){
+//      if(session.getAttribute("loginMember.admin_fl()") == "2" ){
 //      log.info("미인증 요청");
 //      response.sendRedirect("/redirectUrl=" + redirectUrl);
 //      return false;
 //    }
+
     return true;
   }
 

--- a/src/main/resources/templates/login/loginForm.html
+++ b/src/main/resources/templates/login/loginForm.html
@@ -60,8 +60,8 @@
       <button type="submit" >로그인</button>
     </li>
     <li>
-      <a href="#" th:href="@{/member/findid}">아이디찾기</a>
-      <a href="#" th:href="@{/member/findpw}">비밀번호찾기</a>
+      <a href="#" th:href="@{/memberexist/findid}">아이디찾기</a>
+      <a href="#" th:href="@{/memberexist/findpw}">비밀번호찾기</a>
       <a href="#" th:href="@{/signup}">회원가입</a>
     </li>
   </ul>

--- a/src/main/resources/templates/main/mainDetail.html
+++ b/src/main/resources/templates/main/mainDetail.html
@@ -131,7 +131,7 @@
 
     </style>
 </head>
-<body th:with="loginMember = ${session.loginMember}">
+<!--<body th:with="loginMember = ${session.loginMember}">-->
 
 <!--<ul>-->
 <!--    <li><a th:href="@{|/member/${loginMember.id}/out|}">탈퇴</a></li>-->
@@ -144,6 +144,9 @@
             <button type="submit" onclick="location.href='./bookapi.html'"> 찾기 </button>
         </div>
         <div class="upper-right">
+<!--            <span th:if="${!session.isEmpty()}" th:text="${session.loginMember.nickname}"></span>님 환영합니다.-->
+            <span th:if="${!session.isEmpty()}" th:text="${session.loginMember.nickname}"></span>님 환영합니다.
+
             <button type="submit" onclick="location.href='member/memberinfo'"> 마이페이지 </button>
             <button type="submit" onclick="location.href='/logout'"> 로그아웃 </button>
 <!--            <button type="submit" onclick=location.href=/member/out> 탈퇴 </button>-->

--- a/src/main/resources/templates/member/adminMemberList.html
+++ b/src/main/resources/templates/member/adminMemberList.html
@@ -33,21 +33,23 @@
       <tr th:each="member : ${memberAll}">
         <th:block th:if="${memberStat.first}">
           <td class="first-row" th:text="${memberStat.count}"></td>
-          <td class="first-row" ><a th:href="@{|/admin/member/${member.id}/|}" th:text="${member.id}"></a></td>
+<!--          <td class="first-row" ><a th:href="@{|/admin/member/${member.id}/|}" th:text="${member.id}"></a></td>-->
+          <td class="first-row" ><a th:href="@{|/admin/memberdetail/|}" th:text="${member.id}"></a></td>
           <td class="first-row" th:text="${member.name}"></td>
           <td class="first-row" th:text="${member.email}"></td>
           <td class="first-row" th:text="${member.nickname}"></td>
-<!--          <td class="first-row" th:text="${member.signup_dt}"></td>-->
-<!--          <td class="first-row" th:text="${member.leave_fl}"></td>-->
+          <td class="first-row" th:text="${member.signup_dt}"></td>
+          <td class="first-row" th:text="${member.leave_fl}"></td>
         </th:block>
         <th:block th:unless="${memberStat.first}">
           <td th:text="${memberStat.count}"></td>
-          <td> <a th:href="@{|/admin/member/${member.id}/|}" th:text="${member.id}"></a></td>
+<!--          <td> <a th:href="@{|/admin/member/${member.id}/|}" th:text="${member.id}"></a></td>-->
+          <td> <a th:href="@{|/admin/memberdetail/|}" th:text="${member.id}"></a></td>
           <td th:text="${member.name}"></td>
           <td th:text="${member.email}"></td>
           <td th:text="${member.nickname}"></td>
-<!--          <td th:text="${member.signup_dt}"></td>-->
-<!--          <td th:text="${member.leave_fl}"></td>-->
+          <td th:text="${member.signup_dt}"></td>
+          <td th:text="${member.leave_fl}"></td>
         </th:block>
       </tr>
     </tbody>
@@ -57,9 +59,6 @@
   <p>
     회원 상세 보기를 실시 할 경우 템플릿 오류로 인하여 진행이 안됨
   </p>
-  <P>가입일과 탈퇴여부를 보기 위해서는 MemberDTO에 추가하면서 SignupController에도 수정해야한다 </br>
-    LocalDateTime 로 진행 할 경우 개인정보 수정에서 오류가 발생함에 형식을 확인해야 함
-  </P>
 </div>
 
 

--- a/src/main/resources/templates/member/findIdForm.html
+++ b/src/main/resources/templates/member/findIdForm.html
@@ -31,20 +31,20 @@
     findIdBtn.addEventListener('click', findById);
 
 
-    fetch(`/api/comments/${search.value}`,{
-      method:'PATCH',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify(data)
-    }).then(res=>res.json())
-      .then(res=>{console.log(res); findAll_f();})
-      .catch(err=>console.error('Err:',err))    ;
+<!--    fetch(`/api/comments/${search.value}`,{-->
+<!--      method:'PATCH',-->
+<!--      headers:{'Content-Type':'application/json'},-->
+<!--      body:JSON.stringify(data)-->
+<!--    }).then(res=>res.json())-->
+<!--      .then(res=>{console.log(res); findAll_f();})-->
+<!--      .catch(err=>console.error('Err:',err))    ;-->
 
     function findById(e){
         const data ={};
     data.name = nameTxt.value;
     data.email = emailTxt.value;
 
-        fetch('/api/findid',{
+        fetch('/memberexist/exist/findid',{
       method:'PUT',
       headers:{'Content-Type':'application/json'},
       body:JSON.stringify(data)

--- a/src/main/resources/templates/member/findPwForm.html
+++ b/src/main/resources/templates/member/findPwForm.html
@@ -34,13 +34,13 @@
     findPwBtn.addEventListener('click', findByPw);
 
 
-    fetch(`/api/comments/${search.value}`,{
-      method:'PATCH',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify(data)
-    }).then(res=>res.json())
-      .then(res=>{console.log(res); findAll_f();})
-      .catch(err=>console.error('Err:',err))    ;
+<!--    fetch(`/api/comments/${search.value}`,{-->
+<!--      method:'PATCH',-->
+<!--      headers:{'Content-Type':'application/json'},-->
+<!--      body:JSON.stringify(data)-->
+<!--    }).then(res=>res.json())-->
+<!--      .then(res=>{console.log(res); findAll_f();})-->
+<!--      .catch(err=>console.error('Err:',err))    ;-->
 
     function findByPw(e){
         const data ={};
@@ -48,7 +48,7 @@
     data.name = nameTxt.value;
     data.email = emailTxt.value;
 
-        fetch('/api/findpw',{
+        fetch('/memberexist/exist/findpw',{
       method:'PUT',
       headers:{'Content-Type':'application/json'},
       body:JSON.stringify(data)

--- a/src/main/resources/templates/member/memberEditForm.html
+++ b/src/main/resources/templates/member/memberEditForm.html
@@ -2,77 +2,70 @@
 <html lang="ko"
       xmlns:th="http://www.thymeleaf.org">
 <head>
-  <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
-
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>회원정보 수정</title>
+
 
 </head>
 <body>
+<form  th:method="patch" th:action="@{/member/edit}" th:object="${editForm}" >
+  <ul>
+    <li><h3>회원 수정</h3></li>
+    <li>
+      <label for="id" th:for="${#ids.next('id')}">아이디</label>
+      <input type="text" name="id" id="id" th:field="*{id}" readonly/>
+    </li>
 
-<main>
-  <div>
+    <li>
+      <label for="name" th:for="${#ids.next('name')}">이름</label>
+      <input type="text" name="name" id="name" th:field="*{name}" readonly/>
+    </li>
 
-    <form  th:method="patch" th:action="@{/member/edit}" th:object="${editForm}" >
+    <li>
+      <label for="email" th:for="${#ids.next('email')}">Email</label>
+      <input type="text" name="email" id="email" th:field="*{email}"
+             th:class="${#fields.hasErrors('email') ? 'fieldError' : 'fieldSuccess'}">
+      <button id="emailDupChk" type="button">중복확인</button>
+      <p class="errmsg"></p>
+    </li>
+    <li th:if="${#fields.hasErrors('email')}">
+      <p th:errors="*{email}" th:errorclass="fieldError"></p>
+    </li>
 
-      <ul>
-        <li class="title"><h1 class="title">회원 수정</h1></li>
 
-        <li><label for="id" class="form-label">아이디</label></li>
-        <li><input id="id" class="form-control" type="text" th:field="*{id}" readonly/></li>
+    <li>
+      <label for="nickname" th:for="${#ids.next('nickname')}">별칭</label>
+      <input type="text" name="nickname" id="nickname" th:field="*{nickname}"
+             th:class="${#fields.hasErrors('nickname') ? 'fieldError' : 'fieldSuccess'}">
+      <button id="nicknameDupChk" type="button">중복확인</button>
+      <p class="errmsg"></p>
+    </li>
+    <li th:if="${#fields.hasErrors('nickname')}">
+      <p th:errors="*{nickname}" th:errorclass="fieldError"></p>
+    </li>
 
-        <li><label class="form-label" for="name">이름</label></li>
-        <li><input class="form-control" type="text"  th:field="*{name}" readonly/></li>
+    <li class=button>
+      <button class="btn btn-success btn-block" type="submit" onclick="return confirm('정말로 수정 하시겠습니까?')" id="modifyBtn">수정하기</button>
+      <button class="btn btn-success btn-block" type="reset" onclick="location.href='/'">취소</button>
+    </li>
 
-        <li><label class="form-label" for="nickname">닉네임</label></li>
-<!--        <li><input class="form-control" type="text" name="nickname" th:field="*{nickname}" /></li>-->
-<!--        <li th:errors="*{nickname}" th:errorclass="field-msg"></li>-->
-
-        <input type="text" name="nickname" id="nickname" th:field="*{nickname}"
-               th:class="${#fields.hasErrors('nickname') ? 'fieldError' : 'fieldSuccess'}">
-        <button id="nicknameDupChk" type="button">중복확인</button>
-        <p class="errmsg"></p>
-        </li>
-        <li th:if="${#fields.hasErrors('nickname')}">
-          <p th:errors="*{nickname}" th:errorclass="fieldError"></p>
-        </li>
-
-        <li><label class="form-label" for="email">이메일</label></li>
-<!--        <li><input class="form-control" type="text" name="email" th:field="*{email}" /></li>-->
-<!--        <li th:errors="*{email}" th:errorclass="field-msg"></li>-->
-
-        <input type="text" name="email" id="email" th:field="*{email}"
-               th:class="${#fields.hasErrors('email') ? 'fieldError' : 'fieldSuccess'}">
-        <button id="emailDupChk" type="button">중복확인</button>
-        <p class="errmsg"></p>
-        </li>
-        <li th:if="${#fields.hasErrors('email')}">
-          <p th:errors="*{email}" th:errorclass="fieldError"></p>
-        </li>
-
-        <li class=button>
-          <button class="btn btn-success btn-block" type="submit" onclick="return confirm('정말로 수정 하시겠습니까?')" id="modifyBtn">수정하기</button>
-          <button class="btn btn-success btn-block" type="reset" onclick="location.href='/'">취소</button>
-<!--          <button class="btn btn-success btn-block" type="submit" th:formaction="@{|/member/${loginMember.id}/out|}" onclick="return confirm('정말로 탈퇴 하시겠습니까?')">탈퇴</button>-->
-        </li>
-      </ul>
-    </form>
-  </div>
+  </ul>
 
   <div>
-    <P>
-      중복확인 버튼 클릭시 메시지 확인 불가함에 조정 필요
-    </P>
+    <p>
+      중복확인버튼이 사용가능으로 되었을 때에 중복되는 값을 재입력시 사용가능 버튼이 변동이 없음
+    </p>
   </div>
 
 
-</main>
+</form>
 
 
-<!--<footer th:replace="/fragment/fragment_footer :: fragment_footer">-->
-<!--  연습용 빈 footer입니다.-->
 
 <script>
-<!--  console.log(${editForm});-->
+
 
     const $email       = document.getElementById('email');
     const $emailDupChk = document.getElementById('emailDupChk');
@@ -80,7 +73,7 @@
     $emailDupChk.addEventListener('click', e=>{
       const xmlHttpreq = new XMLHttpRequest();
 
-      const url = `/email/${$email.value}/exist`;
+      const url = `/memberexist/email/${$email.value}/exist`;
       xmlHttpreq.open("GET",url);
       xmlHttpreq.send(email);
 
@@ -110,14 +103,13 @@
       });
     });
 
-
     const $nickname       = document.getElementById('nickname');
     const $nicknameDupChk = document.getElementById('nicknameDupChk');
 
     $nicknameDupChk.addEventListener('click', e=>{
       const xmlHttpreq = new XMLHttpRequest();
 
-      const url = `/nickname/${$nickname.value}/exist`;
+      const url = `/memberexist/nickname/${$nickname.value}/exist`;
       xmlHttpreq.open("GET",url);
       xmlHttpreq.send(nickname);
 
@@ -147,13 +139,6 @@
       });
     });
 
-    
-
-
-
-
-</script>
+  </script>
 </body>
 </html>
-
-

--- a/src/main/resources/templates/member/outForm.html
+++ b/src/main/resources/templates/member/outForm.html
@@ -5,38 +5,62 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>회원탈퇴</title>
-  <link rel="stylesheet" th:href="@{/css/common.css}">
-</head>
 
+  <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+
+  <title>회원탈퇴</title>
+
+</head>
 <body>
-<h3>회원탈퇴</h3>
-<hr>
-<form id="frm" action="/member/out" method="get" th:object="${outForm}">
-  <input type="hidden" th:field="*{id}" th:value="${session.loginMember.id}">
-  <ul>
-    <li>
-      <p>탈퇴한 아이디는 본인과 타인 모두 재사용 및 복구가 불가하오니 신중하게 선택하시기 바랍니다.</p>
-    </li>
-    <li>
-      <label for="">비밀번호</label>
-      <input type="password" name="pw" th:field="*{pw}">
-    </li>
-    <li th:if="${#fields.hasErrors('pw')}">
-<!--      <p th:errors="*{pw}" th:errorclass="fieldError"></p>-->
-    </li>
-    <li>
-      <input type="checkbox" name="agree" id="" th:field="*{agree}">
-      <label for="">안내 사항을 모두 확인하였으며, 이에 동의합니다</label>
-    </li>
-    <li th:if="${#fields.hasErrors('agree')}">
-      <p th:errors="*{agree}" th:errorclass="fieldError"></p>
-    </li>
-    <li>
-      <button type="button" id="outBtn">탈퇴</button>
-    </li>
-  </ul>
-</form>
+
+<main>
+  <div>
+
+    <form  id="frm" th:method="patch" th:action="@{/member/out}" th:object="${outForm}" >
+
+      <ul>
+        <li class="title"><h1 class="title">회원탈퇴</h1></li>
+
+        <li><label for="id" class="form-label">아이디</label></li>
+        <li><input id="id" class="form-control" type="text" th:field="*{id}" readonly/></li>
+
+        <li><label class="form-label" for="name">이름</label></li>
+        <input type="text" name="name" id="name" th:field="*{nickname}" readonly/></li>
+
+        <li><label class="form-label" for="nickname">닉네임</label></li>
+        <input type="text" name="nickname" id="nickname" th:field="*{nickname}" readonly/></li>
+
+        <li><label class="form-label" for="email">이메일</label></li>
+        <input type="text" name="email" id="email" th:field="*{email}" readonly/></li>
+
+        <li>
+          <p>탈퇴한 아이디는 본인과 타인 모두 재사용 및 복구가 불가하오니 신중하게 선택하시기 바랍니다.</p>
+        </li>
+        <li>
+          <label for="">비밀번호</label>
+          <input type="password" name="pw" th:field="*{pw}">
+        </li>
+        <li th:if="${#fields.hasErrors('pw')}">
+    <!--      <p th:errors="*{pw}" th:errorclass="fieldError"></p>-->
+        </li>
+        <li>
+          <input type="checkbox" name="agree" id="" th:field="*{agree}">
+          <label for="">안내 사항을 모두 확인하였으며, 이에 동의합니다</label>
+        </li>
+        <li th:if="${#fields.hasErrors('agree')}">
+          <p th:errors="*{agree}" th:errorclass="fieldError"></p>
+        </li>
+        <li>
+          <button type="button" id="outBtn">탈퇴</button>
+        </li>
+
+
+      </ul>
+    </form>
+  </div>
+
+</main>
+
 <script>
     outBtn.addEventListener('click',function(e){
       e.preventDefault(); // 기본이벤트 막기
@@ -45,7 +69,8 @@
       }
     });
 
-
-  </script>
+</script>
 </body>
 </html>
+
+

--- a/src/main/resources/templates/member/outForm_old.html
+++ b/src/main/resources/templates/member/outForm_old.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>회원탈퇴</title>
+<!--  <link rel="stylesheet" th:href="@{/css/common.css}">-->
+</head>
+
+<body>
+<h3>회원탈퇴</h3>
+<hr>
+<form id="frm" action="/member/out" method="post" th:object="${outForm}">
+  <input type="hidden" th:field="*{id}" th:value="${session.loginMember.id}">
+  <ul>
+    <li>
+      <p>탈퇴한 아이디는 본인과 타인 모두 재사용 및 복구가 불가하오니 신중하게 선택하시기 바랍니다.</p>
+    </li>
+    <li>
+      <label for="">비밀번호</label>
+      <input type="password" name="pw" th:field="*{pw}">
+    </li>
+    <li th:if="${#fields.hasErrors('pw')}">
+<!--      <p th:errors="*{pw}" th:errorclass="fieldError"></p>-->
+    </li>
+    <li>
+      <input type="checkbox" name="agree" id="" th:field="*{agree}">
+      <label for="">안내 사항을 모두 확인하였으며, 이에 동의합니다</label>
+    </li>
+    <li th:if="${#fields.hasErrors('agree')}">
+      <p th:errors="*{agree}" th:errorclass="fieldError"></p>
+    </li>
+    <li>
+      <button type="button" id="outBtn">탈퇴</button>
+    </li>
+  </ul>
+</form>
+<script>
+    outBtn.addEventListener('click',function(e){
+      e.preventDefault(); // 기본이벤트 막기
+      if(window.confirm('정말 탈퇴하시겠습니까?')){
+        document.getElementById('frm').submit();
+      }
+    });
+
+
+  </script>
+</body>
+</html>

--- a/src/main/resources/templates/signup/signupForm.html
+++ b/src/main/resources/templates/signup/signupForm.html
@@ -94,7 +94,7 @@
     $idDupChk.addEventListener('click', e=>{
       const xmlHttpreq = new XMLHttpRequest();
 
-      const url = `/id/${$id.value}/exist`;
+      const url = `/memberexist/id/${$id.value}/exist`;
       xmlHttpreq.open("GET",url);
       xmlHttpreq.send(id);
 
@@ -123,7 +123,7 @@
         }
       });
     });
-    
+
 
 
 
@@ -138,7 +138,7 @@
     $emailDupChk.addEventListener('click', e=>{
       const xmlHttpreq = new XMLHttpRequest();
 
-      const url = `/email/${$email.value}/exist`;
+      const url = `/memberexist/email/${$email.value}/exist`;
       xmlHttpreq.open("GET",url);
       xmlHttpreq.send(email);
 
@@ -179,7 +179,7 @@
     $nicknameDupChk.addEventListener('click', e=>{
       const xmlHttpreq = new XMLHttpRequest();
 
-      const url = `/nickname/${$nickname.value}/exist`;
+      const url = `/memberexist/nickname/${$nickname.value}/exist`;
       xmlHttpreq.open("GET",url);
       xmlHttpreq.send(nickname);
 
@@ -209,7 +209,7 @@
       });
     });
 
-    
+
 
 
 


### PR DESCRIPTION
 - 컨트롤러 및 html 수정하여 url에 id를 보여주지 않고 탈퇴 진행 완료
2. MemberDTO 관련 수정
 - sql과 동일하게 DTO 적용
 - SignupController에서 MemberDTO의 모든 정보 받을 수 있게 수정
 - 관리자 계정으로 회원리스트 볼 때 가입일과 탈퇴여부 확인됨(세부보기는 오류)
3. 로그인 인증 관련
 - 로그인 할 때 id, name, email, nickname, admin_fl, signup_dt 정보 입력됨
 - 로그인 후 메인화면에 nickname 명 기제 됨
4. 회원정보 수정 관련
 - 중복 사항 표기 완료(재입력시 버튼 변동 없음)
5. 인터셉터 관련 수정
  - javascript의 json 인증 관련하여 오류 수정
  - 관리자 전용 페이지 인터셉터 오류 수정 중